### PR TITLE
Modified global fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,30 @@
 import pytest
+from requests import get
 
 
-@pytest.fixture(scope="session",
-                params=(['http://localhost:8000/', '10.0.2.2'], ['http://httpbin.org/', '50.54.242.152']),
+# Options to get router ip:
+# ['https://api.ipify.org', 'http://bot.whatismyipaddress.com', 'http://ipv4bot.whatismyipaddress.com']
+@pytest.fixture(scope='session',
+                params=[
+                    {
+                        'base_url': 'http://localhost:8000/',
+                        'my_ip': '10.0.2.2'
+                    },
+                    {
+                        'base_url': 'http://httpbin.org/',
+                        'my_ip': get('http://bot.whatismyipaddress.com/').text
+                    }
+                ],
                 ids=['dev', 'prod'])
-def base_url(request):
-    print("Create fixture {}".format(request.param))
+def config(request):
     return request.param
+
+
+@pytest.fixture(scope='session')
+def base_url(config):
+    return config['base_url']
+
+
+@pytest.fixture(scope='session')
+def my_ip(config):
+    return config['my_ip']

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -lsvvv

--- a/test_httpbin_ip.py
+++ b/test_httpbin_ip.py
@@ -1,16 +1,16 @@
 from requests import get
 
 
-def test_ip(base_url):
-    r = get(base_url[0]+'ip')
+# One way is to use config fixture directly
+def test_ip(config):
+    r = get(config['base_url']+'ip')
     assert r.status_code == 200
-    assert r.json()['origin'] == base_url[1]
+    assert r.json()['origin'] == config['my_ip']
 
 
-def test_anything(base_url):
-    r = get(base_url[0] + 'anything')
+# The other way is to use fixtures derived from from the config fixtures
+def test_anything(base_url, my_ip):
+    r = get(base_url + 'anything')
     assert r.status_code == 200
-    assert r.json()['origin'] == base_url[1]
+    assert r.json()['origin'] == my_ip
     assert r.json()['method'] == 'GET'
-
-


### PR DESCRIPTION
Added config fixture and others derived from config.
Added dynamic way of getting router ip.
@09041985 @a-selehov @nicolas13sochi 
please take a look:
 - added 3 global (scope='session') fixtures:
    - `config` is a dictionary that has base_url and my_ip keys and their values.
    - `my_ip` fixture is a string that depends on `config`
    - `base_url` is also a string that depends on `config`

please see how to use either `config` of `my_ip` and `base_url` fixtures in the `test_httpbin_ip.py`